### PR TITLE
Skip metrics that don't exist

### DIFF
--- a/sources/procfs.go
+++ b/sources/procfs.go
@@ -76,7 +76,7 @@ func (s *lustreSource) Update(ch chan<- prometheus.Metric) (err error) {
 			return err
 		}
 		if paths == nil {
-			return nil
+			continue
 		}
 		for _, path := range paths {
 


### PR DESCRIPTION
If a metric doesn't exist, it should be skipped instead of returned. This is especially pertinant when running on certain storage nodes. For example, if running on the MGS node and the OSS metrics are not disabled, the collector would not export MGS metrics as it would return after the first OSS metric is not found.

Signed-Off-By: Robert Clark <robert.d.clark@hpe.com>