### PR TITLE
Remove redundant metric prefixes

### DIFF
--- a/sources/procfs.go
+++ b/sources/procfs.go
@@ -358,7 +358,7 @@ func (s *lustreSource) parseFile(nodeType string, metricType string, path string
 func (s *lustreSource) constMetric(nodeType string, nodeName string, name string, helpText string, value uint64) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, "lustre", name),
+			prometheus.BuildFQName(Namespace, "", name),
 			helpText,
 			[]string{nodeType},
 			nil,
@@ -372,7 +372,7 @@ func (s *lustreSource) constMetric(nodeType string, nodeName string, name string
 func (s *lustreSource) brwMetric(nodeType string, brwOperation string, brwSize string, nodeName string, name string, helpText string, value uint64) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, "lustre", name),
+			prometheus.BuildFQName(Namespace, "", name),
 			helpText,
 			[]string{nodeType, "operation", "size"},
 			nil,


### PR DESCRIPTION
Originally, all metric names began with 'lustre_lustre_'. According to the documentation on BuildFQName, "BuildFQName joins the given three name components by '_'. Empty name components are ignored." Since all of the metrics in the lustre_exporter are in the 'lustre' namespace and a single subsystem, there is no reason to specify a subsystem. Fixes #11.

Signed-Off-By: Robert Clark <robert.d.clark@hpe.com>